### PR TITLE
Switch to the current_style link to load asset css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,9 +4,9 @@
  ****** cP_Starter_Light *****
  *****************************/
  
-@import url("/styled/cP_Starter_Light/css/global.css");
-@import url("/styled/cP_Starter_Light/css/nav.css");
-@import url("/styled/cP_Starter_Light/css/content.css");
-@import url("/styled/cP_Starter_Light/css/responsive.css");
+@import url("/styled/current_style/css/global.css");
+@import url("/styled/current_style/css/nav.css");
+@import url("/styled/current_style/css/content.css");
+@import url("/styled/current_style/css/responsive.css");
 
 


### PR DESCRIPTION
Using the current_style symlink, rather than the hard file-path, to the linked component style-sheets so that the styles are applied correctly when the end-user switches to it.

Related: https://forums.cpanel.net/threads/custom-theme-paper-lantern.639733/#post-2607589